### PR TITLE
Replace CRLF endings from attempt files to LF

### DIFF
--- a/utils/problem.js
+++ b/utils/problem.js
@@ -30,7 +30,7 @@ module.exports = (dirname) => {
 
   exports.verify = function verify(args, done) {
     const filename = args[0];
-    const attempt = fs.readFileSync(filename, 'utf8');
+    const attempt = fs.readFileSync(filename, 'utf8').replace('\r\n', '\n');
     const solution = fs.readFileSync(this.solutionPath, 'utf8');
 
     const parseAST = str =>


### PR DESCRIPTION
Some editors use line endings of \r\n esp. ones on Windows. All solution
files have \n endings. Addresses #51